### PR TITLE
adds organising books by genre

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -44,7 +44,7 @@ jobs:
           # Report only issues of a given confidence level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)
           # confidence: # optional, default is UNDEFINED
           # comma-separated list of paths (glob patterns supported) to exclude from scan (note that these are in addition to the excluded paths provided in the config file) (default: .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg)
-          excluded_paths: tests/test_app.py,tests/test_mfa.py
+          excluded_paths: tests/test_app.py,tests/test_mfa.py,tests/test_genres.py
           # comma-separated list of test IDs to skip
           # skips: # optional, default is DEFAULT
           # path to a .bandit file that supplies command line arguments

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone, timedelta
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
+from sqlalchemy import func
 import pyotp
 import qrcode
 from cryptography.fernet import Fernet, InvalidToken
@@ -1508,8 +1509,8 @@ def index():
     # Split those, trim whitespace, deduplicate and sort for the dropdown.
     raw_genres = db.session.query(Book.genre).filter(
         Book.user_id == current_user.id,
-        Book.genre != None,
-        Book.genre != ''
+        Book.genre.isnot(None),
+        func.trim(Book.genre) != ''
     ).distinct().all()
 
     genre_set = set()

--- a/app.py
+++ b/app.py
@@ -1669,7 +1669,9 @@ def edit_book(id):
         form.title.data = book.title
         form.author.data = book.author
         form.isbn.data = book.isbn
-        form.genre.data = book.genre
+        # Show a normalized genre string in the edit form to avoid
+        # re-introducing leading/trailing whitespace when saving.
+        form.genre.data = normalize_genre_input(book.genre) if book.genre else None
         form.format.data = book.format
         form.status.data = book.status
         form.rating.data = book.rating

--- a/app.py
+++ b/app.py
@@ -1507,7 +1507,9 @@ def index():
     # Build list of individual genres for the current user to populate the UI.
     # Books store comma-separated genre strings (e.g. "Fiction, Mystery, Thriller").
     # Split those, trim whitespace, deduplicate and sort for the dropdown.
-    raw_genres = db.session.query(Book.genre).filter(
+    # Query trimmed genre strings at the SQL level so `distinct()` operates
+    # on normalized values (avoids duplicates like 'Fiction' vs ' Fiction').
+    raw_genres = db.session.query(func.trim(Book.genre)).filter(
         Book.user_id == current_user.id,
         Book.genre.isnot(None),
         func.trim(Book.genre) != ''

--- a/app.py
+++ b/app.py
@@ -704,6 +704,26 @@ def validate_cover_url(url):
     
     return url
 
+
+def normalize_genre_input(value):
+    """Normalize a free-text genre input into a canonical comma-separated string.
+
+    - Splits on commas
+    - Strips whitespace around parts
+    - Drops empty parts
+    - Joins parts with single comma+space
+
+    Returns None if input is empty or results in no parts.
+    """
+    if not value:
+        return None
+    # Ensure it's a string
+    value = str(value)
+    parts = [p.strip() for p in value.split(',') if p.strip()]
+    if not parts:
+        return None
+    return ', '.join(parts)
+
 def generate_recovery_codes(user_id, count=8):
     """Generate recovery codes for a user.
     
@@ -1571,7 +1591,7 @@ def add_book():
                 title=form.title.data,
                 author=form.author.data,
                 isbn=form.isbn.data or None,
-                genre=form.genre.data or None,
+                genre=normalize_genre_input(form.genre.data) or None,
                 format=form.format.data,
                 status=form.status.data,
                 rating=form.rating.data or None,
@@ -1629,7 +1649,7 @@ def edit_book(id):
             book.title = form.title.data
             book.author = form.author.data
             book.isbn = form.isbn.data or None
-            book.genre = form.genre.data or None
+            book.genre = normalize_genre_input(form.genre.data) or None
             book.format = form.format.data
             book.status = form.status.data
             book.rating = form.rating.data or None

--- a/templates/index.html
+++ b/templates/index.html
@@ -308,6 +308,16 @@
         color: #155724;
         border: 1px solid #c3e6cb;
     }
+
+    /* Utility class for screen-reader-only labels */
+    .visually-hidden {
+        position: absolute !important;
+        height: 1px; width: 1px;
+        overflow: hidden;
+        clip: rect(1px, 1px, 1px, 1px);
+        white-space: nowrap; /* added line */
+        border: 0; padding: 0; margin: -1px;
+    }
 </style>
 {% endblock %}
 
@@ -322,7 +332,8 @@
                     <option value="currently_reading" {% if status_filter == 'currently_reading' %}selected{% endif %}>📖 Currently Reading</option>
                     <option value="read" {% if status_filter == 'read' %}selected{% endif %}>✓ Read</option>
                 </select>
-                <select name="genre" class="search-form-select">
+                <label for="genre-select" class="visually-hidden">Filter by genre</label>
+                <select id="genre-select" name="genre" class="search-form-select">
                     <option value="all" {% if genre_filter == 'all' %}selected{% endif %}>All Genres</option>
                     {% for g in genres %}
                         <option value="{{ g }}" {% if genre_filter == g %}selected{% endif %}>{{ g }}</option>

--- a/templates/index.html
+++ b/templates/index.html
@@ -312,7 +312,7 @@
 {% endblock %}
 
 {% block content %}
-    {% if books or search_query or status_filter != 'all' %}
+    {% if books or search_query or status_filter != 'all' or genre_filter != 'all' %}
         <div class="search-container">
             <form method="GET" class="search-form">
                 <input type="text" name="search" placeholder="Search by title, author, ISBN, or genre..." value="{{ search_query }}">
@@ -322,8 +322,14 @@
                     <option value="currently_reading" {% if status_filter == 'currently_reading' %}selected{% endif %}>📖 Currently Reading</option>
                     <option value="read" {% if status_filter == 'read' %}selected{% endif %}>✓ Read</option>
                 </select>
+                <select name="genre" class="search-form-select">
+                    <option value="all" {% if genre_filter == 'all' %}selected{% endif %}>All Genres</option>
+                    {% for g in genres %}
+                        <option value="{{ g }}" {% if genre_filter == g %}selected{% endif %}>{{ g }}</option>
+                    {% endfor %}
+                </select>
                 <button type="submit" class="btn btn-primary">Search</button>
-                {% if search_query or status_filter != 'all' %}
+                {% if search_query or status_filter != 'all' or genre_filter != 'all' %}
                     <a href="{{ url_for('index') }}" class="btn btn-secondary">Clear</a>
                 {% endif %}
             </form>

--- a/tests/test_genres.py
+++ b/tests/test_genres.py
@@ -1,0 +1,60 @@
+import pytest
+from app import app, db, Book, User
+
+
+def test_genre_splitting_and_filter():
+    """Verify comma-separated genres are split, deduplicated and filterable.
+
+    This test creates three books for the logged-in user with compound
+    comma-separated genre fields and checks that the index page shows
+    individual genres and that filtering by a single genre returns
+    the expected books.
+    """
+    # Prepare clean test database and create a user
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.create_all()
+
+        user = User(username='testuser', email='test@example.com')
+        user.set_password('TestPass123!')
+        db.session.add(user)
+        db.session.commit()
+
+        # Create books with compound genres
+        b1 = Book(title='Book A', author='Author A', genre='Fiction, Mystery', user_id=user.id)
+        b2 = Book(title='Book B', author='Author B', genre='Mystery, Thriller', user_id=user.id)
+        b3 = Book(title='Book C', author='Author C', genre='Nonfiction', user_id=user.id)
+        db.session.add_all([b1, b2, b3])
+        db.session.commit()
+
+    # Ensure test config matches other tests (disable rate limiter / CSRF)
+    app.config['TESTING'] = True
+    app.config['RATELIMIT_ENABLED'] = False
+    app.config['WTF_CSRF_ENABLED'] = False
+
+    client = app.test_client()
+    # Log in using the test client so index is accessible
+    rv_login = client.post('/login', data={'email': 'test@example.com', 'password': 'TestPass123!'}, follow_redirects=True)
+    assert rv_login.status_code == 200
+
+    # Index page should include individual genre options
+    rv = client.get('/')
+    assert rv.status_code == 200
+    html = rv.get_data(as_text=True)
+    assert 'Fiction' in html
+    assert 'Mystery' in html
+    assert 'Thriller' in html
+    assert 'Nonfiction' in html
+
+    # Filtering by Fiction should return only Book A
+    rv_fiction = client.get('/?genre=Fiction')
+    html_fiction = rv_fiction.get_data(as_text=True)
+    assert 'Book A' in html_fiction
+    assert 'Book B' not in html_fiction
+
+    # Filtering by Mystery should return both Book A and Book B
+    rv_mystery = client.get('/?genre=Mystery')
+    html_mystery = rv_mystery.get_data(as_text=True)
+    assert 'Book A' in html_mystery
+    assert 'Book B' in html_mystery


### PR DESCRIPTION
This pull request adds support for filtering books by genre on the main page, in addition to the existing status and search filters. The changes include backend logic for extracting and validating genres, updating the query to filter by genre, and updating the frontend to present a genre dropdown and maintain filter state.

**Backend changes for genre filtering:**

* Added logic in `app.py` to extract the list of unique genres for the current user, validate the `genre_filter` parameter, and apply the genre filter to the books query.
* Updated the `index` route in `app.py` to pass the `genres` list and the current `genre_filter` value to the template.

**Frontend changes for genre filtering:**

* Updated `index.html` to show the genre filter dropdown, dynamically populate it with available genres, and ensure the selected genre persists across requests.
* Modified the search form and clear button in `index.html` to account for the new genre filter, so users can clear all filters at once.

Also added some fallback options in case subject field is empty in API response from openlibraye